### PR TITLE
refactored createKeyStream && createValueStream

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var Transform = require('stream').Transform || require('readable-stream').Transform;
 var Duplex = require('stream').Duplex;
+var extend = require('xtend');
 
 module.exports = install;
 
@@ -62,12 +63,12 @@ Pre.prototype.createReadStream = function(opts) {
 
 Pre.prototype.keyStream =
 Pre.prototype.createKeyStream = function(options) {
-  return this.db.createKeyStream.call(this, options);
+  return this.createReadStream(extend(options, { keys: true, values: false }));
 };
 
 Pre.prototype.valueStream =
 Pre.prototype.createValueStream = function(options) {
-  return this.db.createValueStream.call(this, options);
+  return this.createReadStream(extend(options, { keys: false, values: true }));
 };
 
 Pre.prototype.writeStream =

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "set -e; for t in test/*.js; do node $t; done"
   },
   "dependencies": {
-    "readable-stream": "1.1.x"
+    "readable-stream": "1.1.x",
+    "xtend": "~2.1.1"
   },
   "devDependencies": {
     "after": "0.8.x",


### PR DESCRIPTION
tl;dr 'method too smart err'

The reason for this is simple: I thought this module would be used only on top of `level`, so when you call `createKeyStream` that would call the original function from `level` in the context of the `level-prefix` instance. However if there are other modules such as this one that wrap the `level` instance and use some special property / function from the prototype in the `createKeyStream` / `createValueStream` that would break, since `this` would be referring to `level-prefix`.

If you're still unsure on what I'm saying there's a more concrete example: try to use `level-prefix` on top of a `level-store` which uses `multilevel-http` client:

https://gist.github.com/alessioalex/7341121

Can you please push another version on NPM after you merge this? Thanks!
